### PR TITLE
Add custom "on" value

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Configuration sample:
               "on": "osascript -e 'tell application \"iTunes\" to play'",
               "off": "osascript -e 'tell application \"iTunes\" to stop'",
               "state": "osascript -e 'tell application \"iTunes\" to get player state'",
+              "on_value" : "playing",
+              "exact_match": true,
               "ssh": {
                 "user": "me",
                 "host": "mymac",

--- a/config-sample.json
+++ b/config-sample.json
@@ -15,6 +15,8 @@
       "on": "osascript -e 'tell application \"iTunes\" to play'",
       "off": "osascript -e 'tell application \"iTunes\" to stop'",
       "state": "osascript -e 'tell application \"iTunes\" to get player state'",
+      "on_value" : "playing",
+      "exact_match": true,
       "ssh" : {
         "user": "me",
         "host": "mymac",

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function SshAccessory(log, config) {
   this.offCommand = config['off'];
   this.stateCommand = config['state'];
   this.onValue = config['on_value'] || "playing";
-  this.onValue = this.onValue.strip().toLowerCase();
+  this.onValue = this.onValue.trim().toLowerCase();
   this.exactMatch = config['exact_match'] || true;
   this.ssh = assign({
     user: config['user'],

--- a/index.js
+++ b/index.js
@@ -18,12 +18,24 @@ function SshAccessory(log, config) {
   this.onCommand = config['on'];
   this.offCommand = config['off'];
   this.stateCommand = config['state'];
+  this.onValue = config['on_value'] || "playing";
+  this.onValue = this.onValue.strip().toLowerCase();
+  this.exactMatch = config['exact_match'] || true;
   this.ssh = assign({
     user: config['user'],
     host: config['host'],
     password: config['password'],
     key: config['key']
   }, config['ssh']);
+}
+
+SshAccessory.prototype.matchesString = function(match) {
+  if(this.exactMatch) {
+    return (match === this.onValue);
+  }
+  else {
+    return (match.indexOf(this.onValue) > -1);
+  }
 }
 
 SshAccessory.prototype.setState = function(powerOn, callback) {
@@ -57,9 +69,9 @@ SshAccessory.prototype.getState = function(callback) {
   });
 
   stream.on('data', function (data) {
-    var state = data.toString('utf-8').trim();
+    var state = data.toString('utf-8').trim().toLowerCase();
     accessory.log('State of ' + accessory.name + ' is: ' + state);
-    callback(null, state === 'playing' ? true : false);
+    callback(null, accessory.matchesString(state));
   });
 }
 


### PR DESCRIPTION
Currently, the plugin looks for an exact match against the word "playing", which is useful for scripting iTunes but not useful for much else. 

This commit adds the configurable option `on_value` to specify what value the plugin should match against to consider the state "on". A second configurable option `exact_match` allows the user to specify whether the entire output should match `on_value` or whether `on_value` should be a substring of the state command. Matching is always case-insensitive.

Both `on_value` and `exact_match` have been given default values corresponding to current behaviour as to not disrupt any current configurations.
